### PR TITLE
add .codespellrc

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip=.git,*.pdf,*.svg
+ignore-regex=^\s*"image/\S+": ".*


### PR DESCRIPTION
## PR Summary
This PR adds `.codespellrc`, which our contributors guide already says we have. The line 
```
ignore-regex=^\s*"image/\S+": ".*
```
should fix the issue we were having with image data in notebooks.

I merged this branch in to #71, which is now passing pre-commits.

## Related Tickets & Documents
Closes #72 

## PR Checklist
**General**
- [x] PR includes a summary of changes
- [x] Link relevant issues, make one if none exist


<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- Fork this repository and open the PR from your fork. Do not directly work on
  the NCAR/geocat-applications repository.

- The PR title should summarize the changes, for example "Create weighted pearson-r
  correlation coefficient function". Avoid non-descriptive titles such as "Addresses
  issue #229".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- When merging, we prefer to use squash commits.


**PR Etiquette Reminders**
- This PR should be listed as a draft PR until you are ready to request reviewers

- After making changes in accordance with the reviews, re-request your reviewers

- Generally, don't mark conversations as resolved if you didn't open them

- Do mark conversations as resolved *if you opened them* and are satisfied with the changes/discussion.

If you need assistance with your PR, please let the GeoCAT team know by
tagging us with @NCAR/geocat. We can help if reviews are unclear, the recommended changes
seem overly demanding, you would like help in addressing a reviewer's comments,
or if you have been waiting more than a week to hear back on your PR.
-->
