### PR TITLE
Add infrastructure for citations and bibliographies

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -54,10 +54,13 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.mathjax',
     'myst_nb',
-    "sphinx_design",
-    "nbsphinx",
+    'sphinx_design',
+    'nbsphinx',
     'sphinx.ext.extlinks',
+    'sphinxcontrib.bibtex',
 ]
+
+bibtex_bibfiles = ['references.bib']
 
 mathjax_config = {
     'tex2jax': {

--- a/environment.yml
+++ b/environment.yml
@@ -17,5 +17,6 @@ dependencies:
   - sphinx-book-theme
   - myst-nb
   - sphinx-design
+  - sphinxcontrib-bibtex
   - nbsphinx
   - pandas


### PR DESCRIPTION
## PR Summary
Adds infrastructure for citations and bibliographies

## Related Tickets & Documents
Relates to #88
Depends upon #99 

I think we should leave this issue open until we have examples and documentation, but getting this in would allow us to leverage it in the HHM PR if desired.

## Details
What I've done here is set up the infrastructure to support references/citations and bibliographies per the instructions here in the `sphinxcontrib-bibtex` [getting started guide](https://sphinxcontrib-bibtex.readthedocs.io/en/latest/quickstart.html).

I also tested with a local build that this does indeed work with our project and use case.  

There is a bit of nuance to this however.  We'll want to use the `footcite` and `footbibliography` directives rather than the ones [shown in the theme docs](https://sphinx-book-theme.readthedocs.io/en/stable/reference/extensions.html#sphinxcontrib-bibtex-references-and-bibliographies).  

So the process will look something like this:
1. Add your item(s) to the `references.bib` file in the root directory of the repository.
2. Add citations to your page in the relevant markdown / markdown cells similar to [as shown here](https://github.com/executablebooks/sphinx-book-theme/blob/master/docs/reference/extensions.md?plain=1#L6), but using `footcite` rather than `cite`.
3. Add a bibliography to the bottom of your page similar to [as shown here](https://github.com/executablebooks/sphinx-book-theme/blob/master/docs/reference/extensions.md?plain=1#L6), but using `footbibliography` rather than `bibliography`.

This will give us bibliographies at the page level rather than project level.

I tried to write this out a bit better here, but it gets tricky with the formatting.  