### PR TITLE
Fix link appearance

### DIFF
--- a/applications/applications.rst
+++ b/applications/applications.rst
@@ -15,7 +15,7 @@ Python resources by category with relevant context and links to additional resou
 
             .. card:: Time
 
-                - :ref:`Dates and times <datetime.ipynb>`__
+                - `Dates and times <datetime.ipynb>`__
 
     .. grid-item::
 
@@ -24,8 +24,8 @@ Python resources by category with relevant context and links to additional resou
 
             .. card:: Math
 
-                - :ref:`General applied math <general_applied_math.ipynb>`__
-                - :ref:`Spectral analysis <spectral_analysis.ipynb>`__
+                - `General applied math <general_applied_math.ipynb>`__
+                - `Spectral analysis <spectral_analysis.ipynb>`__
 
     .. grid-item::
 
@@ -34,5 +34,5 @@ Python resources by category with relevant context and links to additional resou
 
             .. card:: Geoscience
 
-                - :ref:`Climatology <climatology.ipynb>`_
-                - :ref:`Humid heat metrics <humid_heat_metrics.ipynb>`__
+                - `Climatology <climatology.ipynb>`__
+                - `Humid heat metrics <humid_heat_metrics.ipynb>`__

--- a/index.rst
+++ b/index.rst
@@ -43,7 +43,7 @@ Python Applications
 
             .. card:: Time
 
-                - :ref:`Dates and times <./applications/datetime.ipynb>`__
+                - `Dates and times <./applications/datetime.ipynb>`__
 
     .. grid-item::
 
@@ -52,8 +52,8 @@ Python Applications
 
             .. card:: Math
 
-                - :ref:`General applied math <./applications/general_applied_math.ipynb>`__
-                - :ref:`Spectral analysis <./applications/spectral_analysis.ipynb>`__
+                - `General applied math <./applications/general_applied_math.ipynb>`__
+                - `Spectral analysis <./applications/spectral_analysis.ipynb>`__
 
     .. grid-item::
 
@@ -62,8 +62,8 @@ Python Applications
 
             .. card:: Geoscience
 
-                - :ref:`Climatology <./applications/climatology.ipynb>`_
-                - :ref:`Humid heat metrics <./applications/humid_heat_metrics.ipynb>`__
+                - `Climatology <./applications/climatology.ipynb>`_
+                - `Humid heat metrics <./applications/humid_heat_metrics.ipynb>`__
 
 .. TIP::
     If you're looking for NCL to Python examples, please visit :ref:`ncl_applications`.


### PR DESCRIPTION
## PR Summary
This is a quick fix to address the problem where the links on these pages include the :ref: bit when they render.

I suspect the idea originally was to try something a little more robust so we didn't need to duplicate this code in two files to adjust filepaths for the links.  This doesn't address that, but does make things work and look a little nicer for the time being.

## Related Tickets & Documents
Closes #143