### PR TITLE
Add config file to filter bot PRs from release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot[bot]
+      - pre-commit-ci[bot]


### PR DESCRIPTION
## PR Summary
Adds a `release.yml` config file to filter bot PRs from the automatically generated release notes.

Relevant GitHub docs: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
Example from Scientific Python template: https://github.com/scientific-python/cookie/blob/main/.github/release.yml

Was reminded of this the other day and figured it might be useful here.