### PR TITLE
Attribute automated deploy commits to github-actions bot

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -59,6 +59,8 @@ jobs:
         if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
           publish_dir: ${{ inputs.publish_dir }}
           enable_jekyll: false
           keep_files: true  # This preserves existing previews from open PRs


### PR DESCRIPTION
## PR Summary
Not sure if this is a new option or just not one I saw at the time, but the action we use to deploy the github pages has an option to attribute the commits to a bot username/email. Currently deploy commits are being "authored" by my github account and it would probably be better if they were not.

I do not have a simple way of testing this ahead of time, but here's the [action documentation](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-set-git-username-and-email) showing exactly the changes I've made here.
<img width="771" height="483" alt="image" src="https://github.com/user-attachments/assets/912e8465-8c79-4a5c-a448-05fb34b53017" />


Closes #286