### PR TITLE
Drop custom CSS

### DIFF
--- a/ncl/ncl_index/ncl_index.md
+++ b/ncl/ncl_index/ncl_index.md
@@ -16,17 +16,9 @@ kernelspec:
 ```{code-cell} ipython3
 :tags: [remove-input, full-width]
 
-from IPython.display import HTML, display
 import itables
 import pandas as pd
 
-css = """
-.dt-length {
-  white-space: pre;
-}
-"""
-
-display(HTML(f"<style>{css}</style>" ""))
 
 itables.init_notebook_mode(connected=True)
 


### PR DESCRIPTION
## PR Summary
We no longer need the custom CSS in the NCL Index notebook following an upstream fix.  This removes that.

## Related Tickets & Documents
Relates to #210
